### PR TITLE
Release 2.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>se.swedenconnect.ca</groupId>
   <artifactId>ca-engine</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1</version>
   <packaging>jar</packaging>
 
   <name>CA engine</name>
@@ -16,9 +16,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>21</java.version>
 
-    <bouncy-castle.version>1.83</bouncy-castle.version>
-    <spring.version>7.0.6</spring.version>
-    <sigval.version>2.0.0</sigval.version>
+    <bouncy-castle.version>1.84</bouncy-castle.version>
+    <spring.version>7.0.8</spring.version>
+    <sigval.version>3.0.0</sigval.version>
   </properties>
 
   <licenses>
@@ -80,13 +80,13 @@
       <dependency>
         <groupId>com.nimbusds</groupId>
         <artifactId>nimbus-jose-jwt</artifactId>
-        <version>10.8</version>
+        <version>10.9.1</version>
       </dependency>
 
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
       </dependency>
 
       <dependency>
@@ -110,25 +110,25 @@
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
       </dependency>
 
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>2.0.17</version>
+        <version>2.0.18</version>
       </dependency>
 
       <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
-        <version>1.18.44</version>
+        <version>1.18.46</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5</artifactId>
-        <version>5.4.2</version>
+        <version>5.4.3</version>
       </dependency>
 
     </dependencies>
@@ -155,7 +155,7 @@
     <dependency>
       <groupId>se.swedenconnect.security</groupId>
       <artifactId>credentials-support</artifactId>
-      <version>2.2.0</version>
+      <version>2.2.1</version>
     </dependency>
 
     <dependency>
@@ -172,7 +172,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>2.0.17</version>
+      <version>2.0.18</version>
       <scope>test</scope>
     </dependency>
 
@@ -187,13 +187,13 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
-      <version>6.0.3</version>
+      <version>6.1.0</version>
     </dependency>
 
     <dependency>
       <groupId>se.idsec.utils</groupId>
       <artifactId>print-cert</artifactId>
-      <version>1.0.9</version>
+      <version>1.0.10</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
     <dependency>
       <groupId>se.idsec.utils</groupId>
       <artifactId>print-cert</artifactId>
-      <version>1.0.10</version>
+      <version>1.0.11</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/se/swedenconnect/ca/engine/ca/issuer/CertificateIssuer.java
+++ b/src/main/java/se/swedenconnect/ca/engine/ca/issuer/CertificateIssuer.java
@@ -40,6 +40,9 @@ import se.swedenconnect.ca.engine.utils.CAUtils;
  */
 public abstract class CertificateIssuer {
 
+  /** RFC 5280 §4.1.2.5 "no well-defined expiration date". BC encodes any year > 2049 as GeneralizedTime. */
+  public static final Instant INFINITE_EXPIRY = Instant.parse("9999-12-31T23:59:59Z");
+
   /** Configuration data for a certificate issuer component */
   @Getter
   protected final CertificateIssuerModel certificateIssuerModel;
@@ -84,6 +87,20 @@ public abstract class CertificateIssuer {
    * @return new time with specified offset from current time
    */
   public static Date getOffsetTime(final Duration offsetDuration) {
+    return getOffsetTime(offsetDuration, false);
+  }
+  /**
+   * Utility function calculating the offset time based on duration
+   *
+   * @param offsetDuration offset duration
+   * @param zeroAsInfinite if true, the offset Duration.ZERO is used as infinite, otherwise it is treated as zero
+   * @return new time with specified offset from current time
+   */
+  public static Date getOffsetTime(final Duration offsetDuration, final boolean zeroAsInfinite) {
+    if (zeroAsInfinite && offsetDuration.equals(Duration.ZERO)) {
+      // Set infinite validity
+      return Date.from(INFINITE_EXPIRY);
+    }
     final Instant now = Instant.now();
     final Instant offsetInstant = now.plusMillis(offsetDuration.toMillis());
     return Date.from(offsetInstant);

--- a/src/main/java/se/swedenconnect/ca/engine/ca/issuer/CertificateIssuerModel.java
+++ b/src/main/java/se/swedenconnect/ca/engine/ca/issuer/CertificateIssuerModel.java
@@ -18,6 +18,7 @@ package se.swedenconnect.ca.engine.ca.issuer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.util.Objects;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -45,8 +46,10 @@ public class CertificateIssuerModel {
   @Setter
   private Duration startOffset = Duration.ofSeconds(-15);
 
-  /** Offset duration for setting the not valid after time relative to current time */
-  @Setter
+  /**
+   * Offset duration for setting the not valid after time relative to current time.
+   * A value of Duration.ZERO indicates that the certificate should not expire.
+   */
   private Duration expiryOffset = Duration.ofDays(365);
 
   /** The name of the algorithm used by the crypto provider to sign ASN.1 objects */
@@ -67,9 +70,26 @@ public class CertificateIssuerModel {
    * @throws NoSuchAlgorithmException thrown if the provided algorithm is not recognized
    */
   public CertificateIssuerModel(final String algorithm, final Duration validity) throws NoSuchAlgorithmException {
+    Objects.requireNonNull(algorithm, "algorithm must not be null");
     this.algorithm = algorithm;
     this.algorithmName = CAAlgorithmRegistry.getSigAlgoName(algorithm);
-    this.expiryOffset = validity;
+    setExpiryOffset(validity);
+  }
+
+  public void setExpiryOffset(final Duration expiryOffset) {
+    Objects.requireNonNull(expiryOffset, "expiryOffset must not be null");
+    if (expiryOffset.equals(Duration.ZERO)) {
+      throw new IllegalArgumentException("Expiry offset cannot be zero");
+    }
+    this.expiryOffset = expiryOffset;
+  }
+
+  public void setInfiniteValidity() {
+    this.expiryOffset = Duration.ZERO;
+  }
+
+  public boolean isInfiniteValidity() {
+    return this.expiryOffset.isZero();
   }
 
   /**

--- a/src/main/java/se/swedenconnect/ca/engine/ca/issuer/impl/BasicCertificateIssuer.java
+++ b/src/main/java/se/swedenconnect/ca/engine/ca/issuer/impl/BasicCertificateIssuer.java
@@ -103,7 +103,7 @@ public class BasicCertificateIssuer extends CertificateIssuer {
         this.issuerName,
         this.certificateIssuerModel.getSerialNumberProvider().getSerialNumber(),
         CertificateIssuer.getOffsetTime(this.certificateIssuerModel.getStartOffset()),
-        CertificateIssuer.getOffsetTime(this.certificateIssuerModel.getExpiryOffset()),
+        CertificateIssuer.getOffsetTime(this.certificateIssuerModel.getExpiryOffset(), true),
         this.getX500Name(model.getSubject()),
         model.getPublicKey());
 
@@ -129,7 +129,7 @@ public class BasicCertificateIssuer extends CertificateIssuer {
         this.issuerName,
         this.certificateIssuerModel.getSerialNumberProvider().getSerialNumber(),
         CertificateIssuer.getOffsetTime(this.certificateIssuerModel.getStartOffset()),
-        CertificateIssuer.getOffsetTime(this.certificateIssuerModel.getExpiryOffset()),
+        CertificateIssuer.getOffsetTime(this.certificateIssuerModel.getExpiryOffset(), true),
         this.getX500Name(model.getSubject()),
         model.getPublicKey());
     return certificateBuilder.build(new JcaContentSignerBuilder(this.certificateIssuerModel.getAlgorithmName())

--- a/src/main/java/se/swedenconnect/ca/engine/ca/issuer/impl/SelfIssuedCertificateIssuer.java
+++ b/src/main/java/se/swedenconnect/ca/engine/ca/issuer/impl/SelfIssuedCertificateIssuer.java
@@ -85,7 +85,7 @@ public class SelfIssuedCertificateIssuer extends CertificateIssuer {
         this.getX500Name(model.getSubject()),
         this.certificateIssuerModel.getSerialNumberProvider().getSerialNumber(),
         CertificateIssuer.getOffsetTime(this.certificateIssuerModel.getStartOffset()),
-        CertificateIssuer.getOffsetTime(this.certificateIssuerModel.getExpiryOffset()),
+        CertificateIssuer.getOffsetTime(this.certificateIssuerModel.getExpiryOffset(), true),
         this.getX500Name(model.getSubject()),
         model.getPublicKey());
 
@@ -111,7 +111,7 @@ public class SelfIssuedCertificateIssuer extends CertificateIssuer {
         this.getX500Name(model.getSubject()),
         this.certificateIssuerModel.getSerialNumberProvider().getSerialNumber(),
         CertificateIssuer.getOffsetTime(this.certificateIssuerModel.getStartOffset()),
-        CertificateIssuer.getOffsetTime(this.certificateIssuerModel.getExpiryOffset()),
+        CertificateIssuer.getOffsetTime(this.certificateIssuerModel.getExpiryOffset(), true),
         this.getX500Name(model.getSubject()),
         model.getPublicKey());
     return certificateBuilder.build(

--- a/src/main/java/se/swedenconnect/ca/engine/ca/models/cert/extension/impl/simple/NoRevAvailModel.java
+++ b/src/main/java/se/swedenconnect/ca/engine/ca/models/cert/extension/impl/simple/NoRevAvailModel.java
@@ -15,11 +15,11 @@
  */
 package se.swedenconnect.ca.engine.ca.models.cert.extension.impl.simple;
 
-import org.bouncycastle.asn1.ASN1Object;
-
 import lombok.NoArgsConstructor;
+import org.bouncycastle.asn1.ASN1Object;
 import se.swedenconnect.ca.engine.ca.issuer.CertificateIssuanceException;
 import se.swedenconnect.ca.engine.ca.models.cert.extension.AbstractExtensionModel;
+import se.swedenconnect.cert.extensions.NoRevAvail;
 import se.swedenconnect.cert.extensions.OCSPNoCheck;
 
 /**
@@ -29,17 +29,17 @@ import se.swedenconnect.cert.extensions.OCSPNoCheck;
  * @author Stefan Santesson (stefan@idsec.se)
  */
 @NoArgsConstructor
-public class OCSPNoCheckModel extends AbstractExtensionModel {
+public class NoRevAvailModel extends AbstractExtensionModel {
 
   /** {@inheritDoc} */
   @Override
   protected ExtensionMetadata getExtensionMetadata() {
-    return new ExtensionMetadata(OCSPNoCheck.OID, "OCSP no check", false);
+    return new ExtensionMetadata(NoRevAvail.OID, "NoRevAvail", false);
   }
 
   /** {@inheritDoc} */
   @Override
   protected ASN1Object getExtensionObject() throws CertificateIssuanceException {
-    return OCSPNoCheck.getInstance();
+    return NoRevAvail.getInstance();
   }
 }

--- a/src/main/java/se/swedenconnect/ca/engine/ca/models/cert/impl/AbstractCertificateModelBuilder.java
+++ b/src/main/java/se/swedenconnect/ca/engine/ca/models/cert/impl/AbstractCertificateModelBuilder.java
@@ -44,6 +44,7 @@ import se.swedenconnect.ca.engine.ca.models.cert.extension.impl.simple.AuthnCont
 import se.swedenconnect.ca.engine.ca.models.cert.extension.impl.simple.BasicConstraintsModel;
 import se.swedenconnect.ca.engine.ca.models.cert.extension.impl.simple.ExtendedKeyUsageModel;
 import se.swedenconnect.ca.engine.ca.models.cert.extension.impl.simple.KeyUsageModel;
+import se.swedenconnect.ca.engine.ca.models.cert.extension.impl.simple.NoRevAvailModel;
 import se.swedenconnect.ca.engine.ca.models.cert.extension.impl.simple.OCSPNoCheckModel;
 import se.swedenconnect.ca.engine.ca.models.cert.extension.impl.simple.QCStatementsExtensionModel;
 import se.swedenconnect.cert.extensions.QCStatements;
@@ -117,9 +118,6 @@ public abstract class AbstractCertificateModelBuilder<T extends AbstractCertific
 
   /** true to include a noRevAvail extension */
   protected boolean noRevAvail;
-
-  /** true to set the validity period to infinite */
-  protected boolean infiniteValidity;
 
   /** {@inheritDoc} */
   @Override
@@ -491,7 +489,7 @@ public abstract class AbstractCertificateModelBuilder<T extends AbstractCertific
 
     // NoRevAvail
     if (this.noRevAvail) {
-
+      extm.add(new NoRevAvailModel());
     }
 
     return extm;

--- a/src/main/java/se/swedenconnect/ca/engine/ca/models/cert/impl/AbstractCertificateModelBuilder.java
+++ b/src/main/java/se/swedenconnect/ca/engine/ca/models/cert/impl/AbstractCertificateModelBuilder.java
@@ -369,6 +369,18 @@ public abstract class AbstractCertificateModelBuilder<T extends AbstractCertific
   }
 
   /**
+   * Set noRevAvail
+   *
+   * @param noRevAvail true to include a noRevAvail extension
+   * @return this builder
+   */
+  @SuppressWarnings("unchecked")
+  public T noRevAvail(final boolean noRevAvail) {
+    this.noRevAvail = noRevAvail;
+    return (T) this;
+  }
+
+  /**
    * Add authority and subject key identifiers to a list of extension models
    *
    * @param extensionModelList the extension models for this certificate model builder to which the subject and key

--- a/src/main/java/se/swedenconnect/ca/engine/ca/models/cert/impl/AbstractCertificateModelBuilder.java
+++ b/src/main/java/se/swedenconnect/ca/engine/ca/models/cert/impl/AbstractCertificateModelBuilder.java
@@ -115,6 +115,12 @@ public abstract class AbstractCertificateModelBuilder<T extends AbstractCertific
   /** subject attributes extension model */
   protected SubjDirectoryAttributesModel subjectDirectoryAttributes;
 
+  /** true to include a noRevAvail extension */
+  protected boolean noRevAvail;
+
+  /** true to set the validity period to infinite */
+  protected boolean infiniteValidity;
+
   /** {@inheritDoc} */
   @Override
   public CertificateModel build() throws CertificateIssuanceException {
@@ -482,6 +488,12 @@ public abstract class AbstractCertificateModelBuilder<T extends AbstractCertific
     if (this.ocspNocheck) {
       extm.add(new OCSPNoCheckModel());
     }
+
+    // NoRevAvail
+    if (this.noRevAvail) {
+
+    }
+
     return extm;
   }
 

--- a/src/test/java/se/swedenconnect/ca/engine/ca/issuer/InfiniteValidityTest.java
+++ b/src/test/java/se/swedenconnect/ca/engine/ca/issuer/InfiniteValidityTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2021-2026 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.swedenconnect.ca.engine.ca.issuer;
+
+import org.bouncycastle.asn1.ASN1GeneralizedTime;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import se.swedenconnect.ca.engine.ca.issuer.impl.BasicCertificateIssuer;
+import se.swedenconnect.ca.engine.ca.issuer.impl.SelfIssuedCertificateIssuer;
+import se.swedenconnect.ca.engine.ca.models.cert.CertNameModel;
+import se.swedenconnect.ca.engine.ca.models.cert.CertificateModel;
+import se.swedenconnect.ca.engine.ca.models.cert.CertificateModelBuilder;
+import se.swedenconnect.ca.engine.ca.models.cert.extension.impl.simple.BasicConstraintsModel;
+import se.swedenconnect.ca.engine.ca.models.cert.extension.impl.simple.KeyUsageModel;
+import se.swedenconnect.ca.engine.ca.models.cert.impl.SelfIssuedCertificateModelBuilder;
+import se.swedenconnect.ca.engine.components.CertRequestData;
+import se.swedenconnect.ca.engine.configuration.CAAlgorithmRegistry;
+import se.swedenconnect.ca.engine.utils.CAUtils;
+import se.swedenconnect.security.credential.BasicCredential;
+import se.swedenconnect.security.credential.PkiCredential;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Security;
+import java.security.spec.ECGenParameterSpec;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the "infinite validity" feature: {@code Duration.ZERO} on the {@link CertificateIssuerModel} expiry offset
+ * yields a certificate whose {@code notAfter} is the RFC 5280 §4.1.2.5 "no well-defined expiration date" value
+ * ({@code 99991231235959Z}, encoded as ASN.1 GeneralizedTime), while {@code notBefore} is unaffected.
+ */
+class InfiniteValidityTest {
+
+  private static final String ALGO = CAAlgorithmRegistry.ALGO_ID_SIGNATURE_ECDSA_SHA256;
+
+  private static KeyPair caKeyPair;
+  private static KeyPair eeKeyPair;
+
+  @BeforeAll
+  static void init() throws Exception {
+    if (Security.getProvider("BC") == null) {
+      Security.addProvider(new BouncyCastleProvider());
+    }
+    caKeyPair = generateEcKeyPair();
+    eeKeyPair = generateEcKeyPair();
+  }
+
+  // --- Pure logic: getOffsetTime -------------------------------------------------------------
+
+  @Test
+  void getOffsetTime_zeroWithInfiniteFlag_returnsNoExpiryValue() {
+    assertEquals(Instant.parse("9999-12-31T23:59:59Z"), CertificateIssuer.INFINITE_EXPIRY);
+    final Date notAfter = CertificateIssuer.getOffsetTime(Duration.ZERO, true);
+    assertEquals(Date.from(CertificateIssuer.INFINITE_EXPIRY), notAfter);
+  }
+
+  @Test
+  void getOffsetTime_zeroWithoutInfiniteFlag_isNow_notInfinite() {
+    // This is the notBefore path: ZERO must NOT be treated as infinite here.
+    final Instant result = CertificateIssuer.getOffsetTime(Duration.ZERO, false).toInstant();
+    final Instant now = Instant.now();
+    assertTrue(result.isAfter(now.minusSeconds(60)) && result.isBefore(now.plusSeconds(60)),
+        "Duration.ZERO without the infinite flag must resolve to ~now, not the year 9999");
+  }
+
+  @Test
+  void getOffsetTime_nonZeroWithFlag_isOffsetFromNow() {
+    final Instant result = CertificateIssuer.getOffsetTime(Duration.ofDays(365), true).toInstant();
+    final Instant now = Instant.now();
+    assertTrue(result.isAfter(now) && result.isBefore(CertificateIssuer.INFINITE_EXPIRY),
+        "A non-zero duration must be a normal offset from now, even with the infinite flag set");
+  }
+
+  // --- Model guards --------------------------------------------------------------------------
+
+  @Test
+  void model_setInfiniteValidity_semantics() throws Exception {
+    final CertificateIssuerModel model = new CertificateIssuerModel(ALGO, Duration.ofDays(365));
+    assertTrue(!model.isInfiniteValidity());
+    model.setInfiniteValidity();
+    assertTrue(model.isInfiniteValidity());
+    assertEquals(Duration.ZERO, model.getExpiryOffset());
+  }
+
+  @Test
+  void model_zeroExpiry_isRejectedOnEveryPath() {
+    assertThrows(IllegalArgumentException.class, () -> new CertificateIssuerModel(ALGO, Duration.ZERO));
+    assertThrows(IllegalArgumentException.class, () -> {
+      final CertificateIssuerModel m = new CertificateIssuerModel(ALGO, Duration.ofDays(1));
+      m.setExpiryOffset(Duration.ZERO);
+    });
+    assertThrows(NullPointerException.class, () -> {
+      final CertificateIssuerModel m = new CertificateIssuerModel(ALGO, Duration.ofDays(1));
+      m.setExpiryOffset(null);
+    });
+  }
+
+  // --- End to end: issued certificates -------------------------------------------------------
+
+  @Test
+  void selfIssued_infiniteValidity_encodesGeneralizedTime() throws Exception {
+    final X509CertificateHolder caCert = issueSelfSignedCa(true);
+    assertInfiniteNotAfter(caCert);
+    assertNotBeforeIsAroundNow(caCert);
+  }
+
+  @Test
+  void basicIssuer_v3_infiniteValidity_encodesGeneralizedTime() throws Exception {
+    final X509CertificateHolder eeCert = issueEndEntity(false /* v1 */);
+    assertEquals(3, eeCert.toASN1Structure().getVersionNumber());
+    assertInfiniteNotAfter(eeCert);
+    assertNotBeforeIsAroundNow(eeCert);
+  }
+
+  @Test
+  void basicIssuer_v1_infiniteValidity_encodesGeneralizedTime() throws Exception {
+    final X509CertificateHolder eeCert = issueEndEntity(true /* v1 */);
+    assertEquals(1, eeCert.toASN1Structure().getVersionNumber());
+    assertInfiniteNotAfter(eeCert);
+    assertNotBeforeIsAroundNow(eeCert);
+  }
+
+  // --- Helpers -------------------------------------------------------------------------------
+
+  /** Issues a self-signed CA certificate, optionally with infinite validity. */
+  private static X509CertificateHolder issueSelfSignedCa(final boolean infinite) throws Exception {
+    final CertificateIssuerModel caModel = new CertificateIssuerModel(ALGO, Duration.ofDays(3650));
+    if (infinite) {
+      caModel.setInfiniteValidity();
+    }
+    final SelfIssuedCertificateIssuer caIssuer = new SelfIssuedCertificateIssuer(caModel);
+    final CertNameModel<?> caName = CertRequestData.getTypicalSubejctName("Test", "CA", "1234567890");
+    final CertificateModelBuilder builder = SelfIssuedCertificateModelBuilder.getInstance(caKeyPair, caModel)
+        .subject(caName)
+        .basicConstraints(new BasicConstraintsModel(true, true))
+        .includeSki(true)
+        .keyUsage(new KeyUsageModel(KeyUsage.keyCertSign + KeyUsage.cRLSign, true));
+    return caIssuer.issueCertificate(builder.build());
+  }
+
+  /** Issues an end-entity certificate from an infinite-validity {@link BasicCertificateIssuer}. */
+  private static X509CertificateHolder issueEndEntity(final boolean v1) throws Exception {
+    final X509CertificateHolder caCert = issueSelfSignedCa(false);
+    final PkiCredential caCredential = new BasicCredential(List.of(CAUtils.getCert(caCert)), caKeyPair.getPrivate());
+
+    final CertificateIssuerModel eeModel = new CertificateIssuerModel(ALGO, Duration.ofDays(365));
+    eeModel.setInfiniteValidity();
+    eeModel.setV1(v1);
+
+    final BasicCertificateIssuer issuer = new BasicCertificateIssuer(eeModel, caCredential);
+    final CertificateModel model = CertificateModel.builder()
+        .subject(CertRequestData.getTypicalSubejctName("John", "Doe", "1234567890"))
+        .publicKey(eeKeyPair.getPublic())
+        .extensionModels(List.of()) // empty -> V1 path taken only when the issuer model has v1=true
+        .build();
+    return issuer.issueCertificate(model);
+  }
+
+  private static void assertInfiniteNotAfter(final X509CertificateHolder holder) {
+    assertTrue(holder.toASN1Structure().getEndDate().toASN1Primitive() instanceof ASN1GeneralizedTime,
+        "notAfter must be encoded as ASN.1 GeneralizedTime");
+    assertEquals(CertificateIssuer.INFINITE_EXPIRY, holder.getNotAfter().toInstant(),
+        "notAfter must be the RFC 5280 no-expiry value 9999-12-31T23:59:59Z");
+  }
+
+  private static void assertNotBeforeIsAroundNow(final X509CertificateHolder holder) {
+    final Instant notBefore = holder.getNotBefore().toInstant();
+    final Instant now = Instant.now();
+    assertTrue(notBefore.isAfter(now.minusSeconds(3600)) && notBefore.isBefore(now.plusSeconds(3600)),
+        "notBefore must be around issuance time, never affected by infinite validity");
+  }
+
+  private static KeyPair generateEcKeyPair() throws Exception {
+    final KeyPairGenerator generator = KeyPairGenerator.getInstance("EC", "BC");
+    generator.initialize(new ECGenParameterSpec("P-256"));
+    return generator.generateKeyPair();
+  }
+}

--- a/src/test/java/se/swedenconnect/ca/engine/ca/issuer/OneSignatureCertificateTest.java
+++ b/src/test/java/se/swedenconnect/ca/engine/ca/issuer/OneSignatureCertificateTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2021-2026 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.swedenconnect.ca.engine.ca.issuer;
+
+import org.bouncycastle.asn1.ASN1GeneralizedTime;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.nist.NISTObjectIdentifiers;
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.util.encoders.Base64;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import lombok.extern.slf4j.Slf4j;
+import se.idsec.utils.printcert.PrintCertificate;
+import se.swedenconnect.ca.engine.ca.attribute.CertAttributes;
+import se.swedenconnect.ca.engine.ca.issuer.impl.BasicCertificateIssuer;
+import se.swedenconnect.ca.engine.ca.issuer.impl.SelfIssuedCertificateIssuer;
+import se.swedenconnect.ca.engine.ca.models.cert.AttributeTypeAndValueModel;
+import se.swedenconnect.ca.engine.ca.models.cert.CertNameModel;
+import se.swedenconnect.ca.engine.ca.models.cert.CertificateModel;
+import se.swedenconnect.ca.engine.ca.models.cert.CertificateModelBuilder;
+import se.swedenconnect.ca.engine.ca.models.cert.extension.impl.GenericExtensionModel;
+import se.swedenconnect.ca.engine.ca.models.cert.extension.impl.simple.BasicConstraintsModel;
+import se.swedenconnect.ca.engine.ca.models.cert.extension.impl.simple.KeyUsageModel;
+import se.swedenconnect.ca.engine.ca.models.cert.impl.DefaultCertificateModelBuilder;
+import se.swedenconnect.ca.engine.ca.models.cert.impl.ExplicitCertNameModel;
+import se.swedenconnect.ca.engine.ca.models.cert.impl.SelfIssuedCertificateModelBuilder;
+import se.swedenconnect.ca.engine.configuration.CAAlgorithmRegistry;
+import se.swedenconnect.ca.engine.utils.CAUtils;
+import se.swedenconnect.cert.extensions.SignedDocumentBinding;
+import se.swedenconnect.security.credential.BasicCredential;
+import se.swedenconnect.security.credential.PkiCredential;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Security;
+import java.security.spec.ECGenParameterSpec;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Issues certificates compliant with {@code draft-ietf-lamps-one-signature-certs}: the signedDocumentBinding
+ * extension, no revocation ({@code noRevAvail}), infinite validity, nonRepudiation key usage, and an AKI.
+ * A range of bindingType identifiers is exercised. Each successfully issued certificate is logged in Base64.
+ */
+@Slf4j
+class OneSignatureCertificateTest {
+
+  private static final String ALGO = CAAlgorithmRegistry.ALGO_ID_SIGNATURE_ECDSA_SHA256;
+
+  /** id-ce-noRevAvail extension OID (2.5.29.56), per RFC 9608. */
+  private static final ASN1ObjectIdentifier NO_REV_AVAIL = new ASN1ObjectIdentifier("2.5.29.56");
+
+  /** A fixed 32-byte "hash of the data to be signed". */
+  private static final byte[] DATA_TBS_HASH = new byte[] {
+      0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+      0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+      0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+      0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20
+  };
+
+  private static final AlgorithmIdentifier SHA256 = new AlgorithmIdentifier(NISTObjectIdentifiers.id_sha256);
+
+  private static KeyPair caKeyPair;
+  private static KeyPair eeKeyPair;
+  private static X509CertificateHolder caCert;
+  private static BasicCertificateIssuer issuer;
+
+  @BeforeAll
+  static void init() throws Exception {
+    if (Security.getProvider("BC") == null) {
+      Security.addProvider(new BouncyCastleProvider());
+    }
+    caKeyPair = generateEcKeyPair();
+    eeKeyPair = generateEcKeyPair();
+
+    // "Example Org CA" self-issued issuer certificate (finite validity - only the EE cert is infinite).
+    final CertificateIssuerModel caModel = new CertificateIssuerModel(ALGO, Duration.ofDays(3650));
+    final SelfIssuedCertificateIssuer caIssuer = new SelfIssuedCertificateIssuer(caModel);
+    final CertificateModelBuilder caBuilder = SelfIssuedCertificateModelBuilder.getInstance(caKeyPair, caModel)
+        .subject(name("Example Org CA"))
+        .basicConstraints(new BasicConstraintsModel(true, true))
+        .includeSki(true)
+        .keyUsage(new KeyUsageModel(KeyUsage.keyCertSign + KeyUsage.cRLSign, true));
+    caCert = caIssuer.issueCertificate(caBuilder.build());
+
+    // Certificate issuer configured for infinite validity.
+    final CertificateIssuerModel eeModel = new CertificateIssuerModel(ALGO, Duration.ofDays(365));
+    eeModel.setInfiniteValidity();
+    final PkiCredential caCredential = new BasicCredential(List.of(CAUtils.getCert(caCert)), caKeyPair.getPrivate());
+    issuer = new BasicCertificateIssuer(eeModel, caCredential);
+  }
+
+  @Test
+  void issueOneSignatureCertificates_variousBindingTypes() throws Exception {
+    // null == default binding (bindingType field omitted); the rest are the registered identifiers.
+    final List<String> bindingTypes = Arrays.asList(null, "cades", "xades", "jws", "cose");
+    for (final String bindingType : bindingTypes) {
+      final X509CertificateHolder cert = issueOneSignatureCert(bindingType);
+      assertCompliant(cert, bindingType);
+      PrintCertificate pc = new PrintCertificate(cert);
+      log.info("One signature certificate (bindingType={}):\n{}\n{}",
+          bindingType == null ? "<default>" : bindingType,
+          pc.toString(true, true, true),
+          pc.toPEM());
+    }
+  }
+
+  private X509CertificateHolder issueOneSignatureCert(final String bindingType) throws Exception {
+    final DefaultCertificateModelBuilder builder =
+        DefaultCertificateModelBuilder.getInstance(eeKeyPair.getPublic(), caCert, issuer.getCertificateIssuerModel())
+            .subject(johnDoe())
+            .includeAki(true)
+            .includeSki(true)
+            .keyUsage(new KeyUsageModel(KeyUsage.nonRepudiation, true))
+            .noRevAvail(true);
+
+    final CertificateModel model = builder.build();
+    // The signedDocumentBinding extension is not a first-class builder property, so add it directly.
+    model.getExtensionModels().add(new GenericExtensionModel(
+        SignedDocumentBinding.OID, new SignedDocumentBinding(DATA_TBS_HASH, SHA256, bindingType)));
+
+    return issuer.issueCertificate(model);
+  }
+
+  private static void assertCompliant(final X509CertificateHolder cert, final String expectedBindingType)
+      throws Exception {
+    // Infinite validity -> notAfter is GeneralizedTime 99991231235959Z.
+    assertTrue(cert.toASN1Structure().getEndDate().toASN1Primitive() instanceof ASN1GeneralizedTime,
+        "notAfter must be GeneralizedTime");
+    assertEquals(CertificateIssuer.INFINITE_EXPIRY, cert.getNotAfter().toInstant());
+
+    // AKI present.
+    assertNotNull(cert.getExtension(Extension.authorityKeyIdentifier), "AKI must be present");
+
+    // Key usage == nonRepudiation only.
+    final KeyUsage keyUsage = KeyUsage.getInstance(cert.getExtension(Extension.keyUsage).getParsedValue());
+    assertTrue(keyUsage.hasUsages(KeyUsage.nonRepudiation), "nonRepudiation must be set");
+    assertTrue(!keyUsage.hasUsages(KeyUsage.digitalSignature), "only nonRepudiation expected");
+
+    // noRevAvail present.
+    assertNotNull(cert.getExtension(NO_REV_AVAIL), "noRevAvail must be present");
+
+    // signedDocumentBinding present and round-trips to the expected bindingType.
+    final Extension sdbExt = cert.getExtension(SignedDocumentBinding.OID);
+    assertNotNull(sdbExt, "signedDocumentBinding must be present");
+    final SignedDocumentBinding sdb = SignedDocumentBinding.getInstance(sdbExt.getParsedValue());
+    assertEquals(expectedBindingType, sdb.getBindingType());
+    assertTrue(sdbExt.isCritical() == false, "signedDocumentBinding SHOULD be non-critical");
+  }
+
+  private static CertNameModel<?> johnDoe() {
+    return name("John Doe");
+  }
+
+  private static CertNameModel<?> name(final String commonName) {
+    return new ExplicitCertNameModel(Arrays.asList(
+        AttributeTypeAndValueModel.builder().attributeType(CertAttributes.C).value("SE").build(),
+        AttributeTypeAndValueModel.builder().attributeType(CertAttributes.O).value("Example Org").build(),
+        AttributeTypeAndValueModel.builder().attributeType(CertAttributes.CN).value(commonName).build()));
+  }
+
+  private static KeyPair generateEcKeyPair() throws Exception {
+    final KeyPairGenerator generator = KeyPairGenerator.getInstance("EC", "BC");
+    generator.initialize(new ECGenParameterSpec("P-256"));
+    return generator.generateKeyPair();
+  }
+}


### PR DESCRIPTION
Signature validation 3.0.0

Added support for:
- noRevAvail
- infinite certificate validity
- signedDocumentBinding (one-signature-certs)
